### PR TITLE
BAH-3528 | Add. uploaded-files Sub Directory And Set Permissions

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -24,3 +24,4 @@ COPY njs.js /etc/nginx/conf.d
 # Create Document Images Directory and modify access mode for other users
 RUN mkdir -p /usr/share/nginx/html/document_images
 RUN mkdir -p /usr/share/nginx/html/uploaded_results
+RUN mkdir -p /usr/share/nginx/html/uploaded-files

--- a/package/docker/default.conf.template
+++ b/package/docker/default.conf.template
@@ -25,6 +25,10 @@ server {
         rewrite ^(.*) https://$host/openmrs/auth?requested_document=$uri permanent;
     }
 
+    location /uploaded-files {
+        rewrite ^(.*) https://$host/openmrs/auth?requested_document=$uri permanent;
+    }
+
     location = /openmrs/auth {
         subrequest_output_buffer_size 200000;
         client_body_buffer_size 200000;

--- a/package/helm/templates/deployment.yaml
+++ b/package/helm/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               name: openmrs-document-images
             - mountPath: /usr/share/nginx/html/uploaded_results
               name: bahmni-uploaded-results
+            - mountPath: /usr/share/nginx/html/uploaded-files
+              name: bahmni-uploaded-files
       restartPolicy: Always
       volumes:
         - name: openmrs-document-images
@@ -68,3 +70,6 @@ spec:
         - name: bahmni-uploaded-results
           persistentVolumeClaim:
             claimName: bahmni-uploaded-results-pvc
+        - name: bahmni-uploaded-files
+          persistentVolumeClaim:
+            claimName: bahmni-uploaded-files-pvc


### PR DESCRIPTION
JIRA -> [BAH-3528](https://bahmni.atlassian.net/browse/BAH-3528)

This PR includes the following changes:

1. Added a mkdir command to create the uploaded-files subdirectory.
2. Set read/write access for the uploaded-files folder and the newly created file.