### PR TITLE
Deepthi M|BAH-3890-fix|updated to responseText as responseBody is removed from njs recent version(after 0.80)

### DIFF
--- a/package/docker/njs.js
+++ b/package/docker/njs.js
@@ -30,7 +30,7 @@ function auth(request) {
 		{ method: "GET" },
 		function (res) {
 			if (res.status === 200) {
-				const jsonData = JSON.parse(res.responseBody)
+				const jsonData = JSON.parse(res.responseText)
 				if (
 					jsonData.authenticated && jsonData.user.privileges &&
 					isAuthorized(jsonData.user.privileges)


### PR DESCRIPTION
Reference link for the change log of njs versions
https://nginx.org/en/docs/njs/reference.html#r_response_body
<img width="844" alt="Screenshot 2024-06-18 at 4 18 29 PM" src="https://github.com/Bahmni/patient-documents/assets/96411257/7a0a224c-e4b0-4ca3-9409-313f129da35f">
