### PR TITLE
BAH-4112 | Fix. Bump Vulnerable Base Image Version

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,5 +1,4 @@
-FROM nginx:1.27.0-alpine
-
+FROM nginx:1.27.1-alpine
 
 RUN apk update
 RUN apk add curl


### PR DESCRIPTION
JIRA -> [BAH-4112](https://bahmni.atlassian.net/browse/BAH-4112)

This PR updates the base image for the Patient Documents image from `nginx:1.27.0-alpine` to `nginx:1.27.1-alpine` to address security vulnerabilities identified in the previous version.

Changes:
Updated the Dockerfile to use `nginx:1.27.1-alpine` as the base image.